### PR TITLE
Feat/0x5459/pc1 label memory numa aware

### DIFF
--- a/rust-fil-proofs.config.toml.sample
+++ b/rust-fil-proofs.config.toml.sample
@@ -40,13 +40,13 @@ use_multicore_sdr = false
 # and you should make sure that the shared memory files stored in this folder were created on that numa node ($NUMA_NODE_INDEX)
 # If using the default value will match the following shared memory files:
 # NUMA node 0:
-# /dev/shm/filecoin-proof-label/numa_0/MEM_32G_1
-# /dev/shm/filecoin-proof-label/numa_0/MEM_64G_1
-# /dev/shm/filecoin-proof-label/numa_0/ANY_FILE_NAME
+# /dev/shm/filecoin-proof-label/numa_0/mem_32GiB_1
+# /dev/shm/filecoin-proof-label/numa_0/mem_64GiB_1
+# /dev/shm/filecoin-proof-label/numa_0/any_file_name
 # NUMA node 1:
-# /dev/shm/filecoin-proof-label/numa_1/MEM_32G_1
-# /dev/shm/filecoin-proof-label/numa_1/MEM_64G_1
-# /dev/shm/filecoin-proof-label/numa_1/ANY_FILE_NAME
+# /dev/shm/filecoin-proof-label/numa_1/mem_32GiB_1
+# /dev/shm/filecoin-proof-label/numa_1/mem_32GiB_1
+# /dev/shm/filecoin-proof-label/numa_1/any_file_name
 # NUMA node N:
 # ...
 # multicore_sdr_shm_numa_dir_pattern = "filecoin-proof-label/numa_$NUMA_NODE_INDEX"

--- a/rust-fil-proofs.config.toml.sample
+++ b/rust-fil-proofs.config.toml.sample
@@ -33,3 +33,20 @@ rows_to_discard = 2
 
 # This enables multicore SDR replication
 use_multicore_sdr = false
+
+# The shared memory directory pattern.
+# default value: "filecoin-proof-label/numa_$NUMA_NODE_INDEX"
+# $NUMA_NODE_INDEX corresponds to the index of the numa node, 
+# and you should make sure that the shared memory files stored in this folder were created on that numa node ($NUMA_NODE_INDEX)
+# If using the default value will match the following shared memory files:
+# NUMA node 0:
+# /dev/shm/filecoin-proof-label/numa_0/MEM_32G_1
+# /dev/shm/filecoin-proof-label/numa_0/MEM_64G_1
+# /dev/shm/filecoin-proof-label/numa_0/ANY_FILE_NAME
+# NUMA node 1:
+# /dev/shm/filecoin-proof-label/numa_1/MEM_32G_1
+# /dev/shm/filecoin-proof-label/numa_1/MEM_64G_1
+# /dev/shm/filecoin-proof-label/numa_1/ANY_FILE_NAME
+# NUMA node N:
+# ...
+# multicore_sdr_shm_numa_dir_pattern = "filecoin-proof-label/numa_$NUMA_NODE_INDEX"

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -47,6 +47,7 @@ semver = "0.11.0"
 fr32 = { path = "../fr32", version = "~4.1.0"}
 pairing = "0.21"
 blstrs = "0.4.0"
+glob = "0.3.0"
 
 [dev-dependencies]
 proptest = "0.10"

--- a/storage-proofs-core/src/settings.rs
+++ b/storage-proofs-core/src/settings.rs
@@ -105,31 +105,29 @@ impl Settings {
         s.try_into()
     }
 
-    pub fn multicore_sdr_shm_numa_dir_pattern<'a>(&self, prefix: &'a str) -> ShmNumaDirPattern<'a> {
+    pub fn multicore_sdr_shm_numa_dir_pattern<'a>(&self, prefix: &'a str) -> ShmNumaDirPattern {
         ShmNumaDirPattern::new(&self.multicore_sdr_shm_numa_dir_pattern, prefix)
     }
 }
 
 /// The shared memory directory pattern
-pub struct ShmNumaDirPattern<'a> {
-    pattern: String,
-    prefix: &'a str,
-}
+pub struct ShmNumaDirPattern(String);
 
-impl<'a> ShmNumaDirPattern<'a> {
+impl ShmNumaDirPattern {
     const NUMA_NODE_IDX_VAR_NAME: &'static str = "$NUMA_NODE_INDEX";
 
-    pub fn new(pattern: &str, prefix: &'a str) -> Self {
-        Self {
-            pattern: glob::Pattern::escape(pattern.trim_matches('/')),
-            prefix: prefix.trim_end_matches('/'),
-        }
+    pub fn new<'a>(pattern: &str, prefix: &'a str) -> Self {
+        Self(format!(
+            "{}/{}",
+            prefix.trim_end_matches('/'),
+            glob::Pattern::escape(pattern.trim_matches('/')),
+        ))
     }
 
     /// Converts to glob pattern
     ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use storage_proofs_core::settings::ShmNumaDirPattern;
     ///
@@ -141,16 +139,15 @@ impl<'a> ShmNumaDirPattern<'a> {
     /// ```
     pub fn to_glob_pattern(&self) -> String {
         format!(
-            "{}/{}/*",
-            self.prefix,
-            self.pattern.replacen(Self::NUMA_NODE_IDX_VAR_NAME, "*", 1)
+            "{}/*",
+            self.0.replacen(Self::NUMA_NODE_IDX_VAR_NAME, "*", 1)
         )
     }
 
     /// Converts to regex pattern
     ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use storage_proofs_core::settings::ShmNumaDirPattern;
     ///
@@ -162,10 +159,8 @@ impl<'a> ShmNumaDirPattern<'a> {
     /// ```
     pub fn to_regex_pattern(&self) -> String {
         format!(
-            "{}/{}/.+",
-            self.prefix,
-            self.pattern
-                .replacen(Self::NUMA_NODE_IDX_VAR_NAME, "(\\d+)", 1)
+            "{}/.+",
+            self.0.replacen(Self::NUMA_NODE_IDX_VAR_NAME, "(\\d+)", 1)
         )
     }
 }

--- a/storage-proofs-core/src/settings.rs
+++ b/storage-proofs-core/src/settings.rs
@@ -105,7 +105,7 @@ impl Settings {
         s.try_into()
     }
 
-    pub fn multicore_sdr_shm_numa_dir_pattern<'a>(&self, prefix: &'a str) -> ShmNumaDirPattern {
+    pub fn multicore_sdr_shm_numa_dir_pattern(&self, prefix: &str) -> ShmNumaDirPattern {
         ShmNumaDirPattern::new(&self.multicore_sdr_shm_numa_dir_pattern, prefix)
     }
 }
@@ -116,7 +116,7 @@ pub struct ShmNumaDirPattern(String);
 impl ShmNumaDirPattern {
     const NUMA_NODE_IDX_VAR_NAME: &'static str = "$NUMA_NODE_INDEX";
 
-    pub fn new<'a>(pattern: &str, prefix: &'a str) -> Self {
+    pub fn new(pattern: &str, prefix: &str) -> Self {
         Self(format!(
             "{}/{}",
             prefix.trim_end_matches('/'),

--- a/storage-proofs-core/src/settings.rs
+++ b/storage-proofs-core/src/settings.rs
@@ -30,6 +30,7 @@ pub struct Settings {
     pub multicore_sdr_producers: usize,
     pub multicore_sdr_producer_stride: u64,
     pub multicore_sdr_lookahead: usize,
+    pub multicore_sdr_shm_numa_dir_pattern: String,
 }
 
 impl Default for Settings {
@@ -54,6 +55,10 @@ impl Default for Settings {
             multicore_sdr_producers: 3,
             multicore_sdr_producer_stride: 128,
             multicore_sdr_lookahead: 800,
+            multicore_sdr_shm_numa_dir_pattern: format!(
+                "filecoin-proof-label/numa_{}",
+                ShmNumaDirPattern::NUMA_NODE_IDX_VAR_NAME
+            ),
         }
     }
 }
@@ -98,5 +103,69 @@ impl Settings {
         s.merge(Environment::with_prefix(PREFIX))?;
 
         s.try_into()
+    }
+
+    pub fn multicore_sdr_shm_numa_dir_pattern<'a>(&self, prefix: &'a str) -> ShmNumaDirPattern<'a> {
+        ShmNumaDirPattern::new(&self.multicore_sdr_shm_numa_dir_pattern, prefix)
+    }
+}
+
+/// The shared memory directory pattern
+pub struct ShmNumaDirPattern<'a> {
+    pattern: String,
+    prefix: &'a str,
+}
+
+impl<'a> ShmNumaDirPattern<'a> {
+    const NUMA_NODE_IDX_VAR_NAME: &'static str = "$NUMA_NODE_INDEX";
+
+    pub fn new(pattern: &str, prefix: &'a str) -> Self {
+        Self {
+            pattern: glob::Pattern::escape(pattern.trim_matches('/')),
+            prefix: prefix.trim_end_matches('/'),
+        }
+    }
+
+    /// Converts to glob pattern
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use storage_proofs_core::settings::ShmNumaDirPattern;
+    ///
+    /// let p = ShmNumaDirPattern::new("abc/numa_$NUMA_NODE_INDEX", "/dev/shm");
+    /// assert_eq!(p.to_glob_pattern(), String::from("/dev/shm/abc/numa_*/*"));
+    ///
+    /// let p = ShmNumaDirPattern::new("abc/nu_$NUMA_NODE_INDEX_ma", "/dev/shm");
+    /// assert_eq!(p.to_glob_pattern(), String::from("/dev/shm/abc/nu_*_ma/*"));
+    /// ```
+    pub fn to_glob_pattern(&self) -> String {
+        format!(
+            "{}/{}/*",
+            self.prefix,
+            self.pattern.replacen(Self::NUMA_NODE_IDX_VAR_NAME, "*", 1)
+        )
+    }
+
+    /// Converts to regex pattern
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use storage_proofs_core::settings::ShmNumaDirPattern;
+    ///
+    /// let p = ShmNumaDirPattern::new("abc/numa_$NUMA_NODE_INDEX", "/dev/shm");
+    /// assert_eq!(p.to_regex_pattern(), String::from(r"/dev/shm/abc/numa_(\d+)/.+"));
+    ///
+    /// let p = ShmNumaDirPattern::new("abc/nu_$NUMA_NODE_INDEX_ma", "/dev/shm");
+    /// assert_eq!(p.to_regex_pattern(), String::from(r"/dev/shm/abc/nu_(\d+)_ma/.+"));
+    /// ```
+    pub fn to_regex_pattern(&self) -> String {
+        format!(
+            "{}/{}/.+",
+            self.prefix,
+            self.pattern
+                .replacen(Self::NUMA_NODE_IDX_VAR_NAME, "(\\d+)", 1)
+        )
     }
 }

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -44,7 +44,7 @@ fil_logger = "0.1"
 pairing = "0.21"
 blstrs = "0.4.0"
 glob = "0.3.0"
-regex = "1.5.6"
+regex = "1"
 
 [target."cfg(target_arch = \"aarch64\")".dependencies]
 sha2 = { version = "0.9.3", features = ["compress", "asm"] }

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -43,6 +43,8 @@ yastl = "0.1.2"
 fil_logger = "0.1"
 pairing = "0.21"
 blstrs = "0.4.0"
+glob = "0.3.0"
+regex = "1.5.6"
 
 [target."cfg(target_arch = \"aarch64\")".dependencies]
 sha2 = { version = "0.9.3", features = ["compress", "asm"] }
@@ -53,7 +55,6 @@ sha2 = { version = "0.9.3", features = ["compress"] }
 tempfile = "3"
 rand_xorshift = "0.3.0"
 criterion = "0.3.2"
-glob = "0.3.0"
 pretty_env_logger = "0.4.0"
 filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
 

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -16,7 +16,6 @@ use generic_array::{
     GenericArray,
 };
 use log::{debug, info};
-use mapr::MmapMut;
 use merkletree::store::{DiskStore, Store, StoreConfig};
 use storage_proofs_core::{
     cache_key::CacheKey,
@@ -203,8 +202,8 @@ fn create_label_runner(
 fn create_layer_labels(
     parents_cache: &CacheReader<u32>,
     replica_id: &[u8],
-    layer_labels: &mut MmapMut,
-    exp_labels: Option<&mut MmapMut>,
+    layer_labels: &mut [u8],
+    exp_labels: Option<&mut [u8]>,
     num_nodes: u64,
     cur_layer: u32,
     core_group: Arc<Option<MutexGuard<'_, Vec<CoreIndex>>>>,

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
@@ -414,7 +414,7 @@ fn numa_pool() -> &'static shm::NumaPool {
 /// /dev/shm/filecoin-proof-label/numa_1/any_file_name
 /// NUMA node N:
 /// ...
-fn scan_shm_files(shm_numa_dir_pattern: &ShmNumaDirPattern<'_>) -> Result<Vec<Vec<PathBuf>>> {
+fn scan_shm_files(shm_numa_dir_pattern: &ShmNumaDirPattern) -> Result<Vec<Vec<PathBuf>>> {
     use glob::glob;
     use regex::Regex;
 
@@ -530,9 +530,8 @@ mod tests {
                     numa_index.to_string().as_str(),
                     1,
                 );
-
                 expected_numa_shm_files[numa_index] =
-                    generated_random_files(tempdir.path().join(dir), count);
+                    generated_random_files(tempdir.path().join(dir.trim_matches('/')), count);
             }
             if expected_numa_shm_files.iter().all(Vec::is_empty) {
                 expected_numa_shm_files = Vec::new();
@@ -558,7 +557,7 @@ mod tests {
                 .map(char::from)
                 .take(len)
                 .collect()
-        };
+        }
 
         let mut rng = rand::thread_rng();
         let dir = dir.as_ref();

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
@@ -405,13 +405,13 @@ fn numa_pool() -> &'static shm::NumaPool {
 /// In the above example, the following shared memory files will be matched.
 ///
 /// NUMA node 0:
-/// /dev/shm/filecoin-proof-label/numa_0/MEM_32G_1
-/// /dev/shm/filecoin-proof-label/numa_0/MEM_64G_1
-/// /dev/shm/filecoin-proof-label/numa_0/ANY_FILE_NAME
+/// /dev/shm/filecoin-proof-label/numa_0/mem_32GiB_1
+/// /dev/shm/filecoin-proof-label/numa_0/mem_64GiB_1
+/// /dev/shm/filecoin-proof-label/numa_0/any_file_name
 /// NUMA node 1:
-/// /dev/shm/filecoin-proof-label/numa_1/MEM_32G_1
-/// /dev/shm/filecoin-proof-label/numa_1/MEM_64G_1
-/// /dev/shm/filecoin-proof-label/numa_1/ANY_FILE_NAME
+/// /dev/shm/filecoin-proof-label/numa_1/mem_32GiB_1
+/// /dev/shm/filecoin-proof-label/numa_1/mem_64GiB_1
+/// /dev/shm/filecoin-proof-label/numa_1/any_file_name
 /// NUMA node N:
 /// ...
 fn scan_shm_files(shm_numa_dir_pattern: &ShmNumaDirPattern<'_>) -> Result<Vec<Vec<PathBuf>>> {

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
@@ -438,7 +438,7 @@ fn scan_shm_files(shm_numa_dir_pattern: &ShmNumaDirPattern) -> Result<Vec<Vec<Pa
         .for_each(|(numa_node_idx, path)| {
             numa_shm_files_map
                 .entry(numa_node_idx)
-                .or_insert_with(|| Vec::new())
+                .or_insert_with(Vec::new)
                 .push(path);
         });
 
@@ -448,7 +448,7 @@ fn scan_shm_files(shm_numa_dir_pattern: &ShmNumaDirPattern) -> Result<Vec<Vec<Pa
         Some(&max_node_idx) => {
             let mut numa_vec = Vec::with_capacity(max_node_idx + 1);
             for i in 0..=max_node_idx {
-                numa_vec.push(numa_shm_files_map.remove(&i).unwrap_or_else(|| Vec::new()))
+                numa_vec.push(numa_shm_files_map.remove(&i).unwrap_or_default())
             }
             numa_vec
         }
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn test_scan_shm_files() {
-        const NUMA_NODE_IDX_VAR_NAME: &'static str = "$NUMA_NODE_INDEX";
+        const NUMA_NODE_IDX_VAR_NAME: &str = "$NUMA_NODE_INDEX";
 
         struct TestCase {
             shm_numa_dir_pattern: String,

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling.rs
@@ -1,16 +1,24 @@
 use std::cell::UnsafeCell;
+use std::collections::HashMap;
 use std::fs::File;
 use std::hint::spin_loop;
 use std::marker::{PhantomData, Sync};
-use std::mem::size_of;
-use std::path::Path;
+use std::mem::{size_of, MaybeUninit};
+use std::ops::{Deref, DerefMut};
+use std::path::{Path, PathBuf};
 use std::slice;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    MutexGuard, Once,
+};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use byte_slice_cast::{AsSliceOf, FromByteSlice};
-use log::{info, warn};
+use log::{debug, info, warn};
 use mapr::{Mmap, MmapMut, MmapOptions};
+use storage_proofs_core::settings::{ShmNumaDirPattern, SETTINGS};
+
+mod shm;
 
 pub struct CacheReader<T> {
     file: File,
@@ -275,7 +283,7 @@ impl<T: FromByteSlice> CacheReader<T> {
     }
 }
 
-fn allocate_layer(sector_size: usize) -> Result<MmapMut> {
+fn normal_allocate_layer(sector_size: usize) -> Result<MmapMut> {
     match MmapOptions::new()
         .len(sector_size)
         .private()
@@ -296,15 +304,278 @@ fn allocate_layer(sector_size: usize) -> Result<MmapMut> {
     }
 }
 
+#[derive(Debug)]
+pub enum Memory {
+    Normal(MmapMut),
+    Shm(MutexGuard<'static, MmapMut>),
+}
+
+impl Deref for Memory {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Memory::Normal(m) => m.deref(),
+            Memory::Shm(m) => m.deref(),
+        }
+    }
+}
+
+impl DerefMut for Memory {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Memory::Normal(m) => m.deref_mut(),
+            Memory::Shm(m) => m.deref_mut(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for Memory {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+impl AsMut<[u8]> for Memory {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.deref_mut()
+    }
+}
+
+fn allocate_layer(sector_size: usize) -> Result<Memory> {
+    Ok(match numa_pool().acquire(sector_size) {
+        Some(shm_mem) => Memory::Shm(shm_mem),
+        None => {
+            debug!("unable to load shm memory, falling back.");
+            Memory::Normal(normal_allocate_layer(sector_size)?)
+        }
+    })
+}
+
 pub fn setup_create_label_memory(
     sector_size: usize,
     degree: usize,
     window_size: Option<usize>,
     cache_path: &Path,
-) -> Result<(CacheReader<u32>, MmapMut, MmapMut)> {
+) -> Result<(CacheReader<u32>, Memory, Memory)> {
     let parents_cache = CacheReader::new(cache_path, window_size, degree)?;
     let layer_labels = allocate_layer(sector_size)?;
     let exp_labels = allocate_layer(sector_size)?;
 
     Ok((parents_cache, layer_labels, exp_labels))
+}
+
+/// Get the static global NUMA pool reference
+fn numa_pool() -> &'static shm::NumaPool {
+    fn init_numa_pool() -> Result<shm::NumaPool> {
+        let shm_numa_dir_pattern = SETTINGS.multicore_sdr_shm_numa_dir_pattern("/dev/shm");
+
+        Ok(shm::NumaPool::new(scan_shm_files(&shm_numa_dir_pattern)?))
+    }
+
+    static mut NUMA_POOL: MaybeUninit<shm::NumaPool> = MaybeUninit::uninit();
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        let numa_pool = match init_numa_pool() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("init numa pool: {:?}", e);
+                shm::NumaPool::empty()
+            }
+        };
+
+        unsafe { NUMA_POOL = MaybeUninit::new(numa_pool) }
+    });
+
+    unsafe { NUMA_POOL.assume_init_ref() }
+}
+
+/// Scan SHM files by the given `shm_numa_dir_pattern`
+///
+/// let p = ShmNumaDirPattern::new("/dev/shm/filecoin-proof-label/numa_$NUMA_NODE_INDEX", "/dev/shm");
+/// scan_shm_files(&p);
+///
+/// $NUMA_NODE_INDEX corresponds to the index of the numa node,
+/// and you should make sure that the shared memory files stored in this folder were created on that numa node ($NUMA_NODE_INDEX)
+/// In the above example, the following shared memory files will be matched.
+///
+/// NUMA node 0:
+/// /dev/shm/filecoin-proof-label/numa_0/MEM_32G_1
+/// /dev/shm/filecoin-proof-label/numa_0/MEM_64G_1
+/// /dev/shm/filecoin-proof-label/numa_0/ANY_FILE_NAME
+/// NUMA node 1:
+/// /dev/shm/filecoin-proof-label/numa_1/MEM_32G_1
+/// /dev/shm/filecoin-proof-label/numa_1/MEM_64G_1
+/// /dev/shm/filecoin-proof-label/numa_1/ANY_FILE_NAME
+/// NUMA node N:
+/// ...
+fn scan_shm_files(shm_numa_dir_pattern: &ShmNumaDirPattern<'_>) -> Result<Vec<Vec<PathBuf>>> {
+    use glob::glob;
+    use regex::Regex;
+
+    let re_numa_node_idx = Regex::new(shm_numa_dir_pattern.to_regex_pattern().as_str())
+        .context("invalid `multicore_sdr_shm_numa_dir_pattern`")?;
+
+    // numa_shm_files_map: { NUMA_NODE_INDEX -> Vec<PathBuf of this numa node shm file> }
+    let mut numa_shm_files_map = HashMap::new();
+    glob(shm_numa_dir_pattern.to_glob_pattern().as_str())
+        .context("invalid `multicore_sdr_shm_numa_dir_pattern`")?
+        .filter_map(|path_res| path_res.ok())
+        .filter_map(|path| {
+            let numa_node_idx: usize = re_numa_node_idx
+                .captures(path.to_str()?)?
+                .get(1)?
+                .as_str()
+                .parse()
+                .ok()?;
+            Some((numa_node_idx, path))
+        })
+        .for_each(|(numa_node_idx, path)| {
+            numa_shm_files_map
+                .entry(numa_node_idx)
+                .or_insert_with(|| Vec::new())
+                .push(path);
+        });
+
+    // Converts the numa_shm_files_map { NUMA_NODE_INDEX -> Vec<PathBuf of this numa node shm file> }
+    // to numa_shm_files Vec [ NUMA_NODE_INDEX -> Vec<PathBuf of this numa node shm file> ]
+    let numa_shm_files = match numa_shm_files_map.keys().max() {
+        Some(&max_node_idx) => {
+            let mut numa_vec = Vec::with_capacity(max_node_idx + 1);
+            for i in 0..=max_node_idx {
+                numa_vec.push(numa_shm_files_map.remove(&i).unwrap_or_else(|| Vec::new()))
+            }
+            numa_vec
+        }
+        None => Vec::new(),
+    };
+    Ok(numa_shm_files)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        fs,
+        iter::repeat,
+        path::{Path, PathBuf},
+    };
+
+    use rand::{distributions::Alphanumeric, prelude::ThreadRng, Rng};
+    use storage_proofs_core::settings::ShmNumaDirPattern;
+
+    use crate::stacked::vanilla::memory_handling::scan_shm_files;
+
+    #[test]
+    fn test_scan_shm_files() {
+        const NUMA_NODE_IDX_VAR_NAME: &'static str = "$NUMA_NODE_INDEX";
+
+        struct TestCase {
+            shm_numa_dir_pattern: String,
+            // { numa_node_idx -> shm files count of this numa node }
+            numa_node_files: HashMap<usize, usize>,
+        }
+        let cases = vec![
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/numa_{}", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 4), (1, 0), (3, 2)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/123/numa_{}", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 4), (1, 0), (3, 2)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/123/nu_{}_ma", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 4), (1, 0), (3, 2)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/123/nu_{}_ma/546", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 4), (1, 0), (3, 2)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/123/中{}文", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 4), (1, 0), (3, 2)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("/abc/123/nu_{}_ma/546/", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 4), (1, 2), (2, 3), (3, 2)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("///abc/123/nu_{}_ma/546///", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/123/nu_{}_ma/546", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: vec![(3, 0)].into_iter().collect(),
+            },
+            TestCase {
+                shm_numa_dir_pattern: format!("abc/123/nu_{}_ma/546", NUMA_NODE_IDX_VAR_NAME),
+                numa_node_files: Default::default(),
+            },
+        ];
+
+        for c in cases {
+            let tempdir = tempfile::tempdir().expect("Failed to create tempdir");
+
+            let numa_node_num = *c.numa_node_files.keys().max().unwrap_or(&0) + 1;
+            let mut expected_numa_shm_files = vec![vec![]; numa_node_num];
+            for (numa_index, count) in c.numa_node_files {
+                let dir = c.shm_numa_dir_pattern.replacen(
+                    NUMA_NODE_IDX_VAR_NAME,
+                    numa_index.to_string().as_str(),
+                    1,
+                );
+
+                expected_numa_shm_files[numa_index] =
+                    generated_random_files(tempdir.path().join(dir), count);
+            }
+            if expected_numa_shm_files.iter().all(Vec::is_empty) {
+                expected_numa_shm_files = Vec::new();
+            }
+
+            let p =
+                ShmNumaDirPattern::new(&c.shm_numa_dir_pattern, tempdir.path().to_str().unwrap());
+            let mut actually_numa_shm_files =
+                scan_shm_files(&p).expect("scan shm files must be ok");
+            actually_numa_shm_files
+                .iter_mut()
+                .for_each(|files| files.sort());
+
+            assert_eq!(expected_numa_shm_files, actually_numa_shm_files);
+        }
+    }
+
+    fn generated_random_files(dir: impl AsRef<Path>, count: usize) -> Vec<PathBuf> {
+        fn filename_fn(rng: &mut ThreadRng) -> String {
+            let len = rng.gen_range(1..=30);
+            repeat(())
+                .map(|()| rng.sample(Alphanumeric))
+                .map(char::from)
+                .take(len)
+                .collect()
+        };
+
+        let mut rng = rand::thread_rng();
+        let dir = dir.as_ref();
+        fs::create_dir_all(dir).expect("Failed to create dir");
+
+        let mut files: Vec<PathBuf> = (0..count)
+            .map(|_| {
+                let filename = filename_fn(&mut rng);
+                let p = dir.join(filename);
+                let mut data = vec![0; rng.gen_range(0..100)];
+                rng.fill(data.as_mut_slice());
+                fs::write(&p, &data).expect("Failed to write random data");
+                p
+            })
+            .collect();
+
+        files.sort();
+        files
+    }
 }

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
@@ -1,0 +1,220 @@
+use std::{
+    collections::HashMap,
+    fs::OpenOptions,
+    path::Path,
+    sync::{Mutex, MutexGuard},
+};
+
+use log::{info, warn};
+use mapr::{MmapMut, MmapOptions};
+
+use crate::stacked::vanilla::numa::NumaNodeIndex;
+
+// memory_size -> memory
+type ShmPool = HashMap<usize, Vec<Mutex<MmapMut>>>;
+
+pub(super) struct NumaPool {
+    /// The index of the numa_groups vec is numa_node_index
+    numa_groups: Vec<ShmPool>,
+}
+
+impl NumaPool {
+    /// Create an empty NumaPoll
+    pub fn empty() -> Self {
+        Self {
+            numa_groups: Vec::new(),
+        }
+    }
+
+    /// Create NumaPool with the given numa_shm_files
+    ///
+    /// The index of the numa_shm_files vec is numa_node_index,
+    /// and each item of numa_shm_files is the shm file paths corresponding to numa_node_index
+    pub fn new(numa_shm_files: Vec<impl IntoIterator<Item = impl AsRef<Path>>>) -> Self {
+        let numa_groups = numa_shm_files
+            .into_iter()
+            .map(Self::load_shm_files)
+            .collect();
+        Self { numa_groups }
+    }
+
+    fn load_shm_files(shm_files: impl IntoIterator<Item = impl AsRef<Path>>) -> ShmPool {
+        let mut shm_pool: HashMap<usize, Vec<Mutex<MmapMut>>> = HashMap::new();
+
+        for p in shm_files.into_iter() {
+            let p = p.as_ref();
+            let shm_file = match OpenOptions::new().read(true).write(true).open(p) {
+                Ok(file) => file,
+                Err(e) => {
+                    warn!(
+                        "open shm file: '{}', {:?}. ignore this shm file.",
+                        p.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            let file_size = match shm_file.metadata() {
+                Ok(meta) => meta.len(),
+                Err(e) => {
+                    warn!(
+                        "get the size of the '{}' file: {:?}. ignore this shm file.",
+                        p.display(),
+                        e,
+                    );
+                    continue;
+                }
+            };
+
+            let mmap = match unsafe { MmapOptions::new().lock().map_mut(&shm_file) } {
+                Ok(mmap) => mmap,
+                Err(e) => {
+                    // fallback to not locked if permissions are not available
+                    warn!(
+                        "lock mmap shm file '{}': {:?}. falling back",
+                        p.display(),
+                        e
+                    );
+                    match unsafe { MmapOptions::new().map_mut(&shm_file) } {
+                        Ok(mmap) => mmap,
+                        Err(e) => {
+                            warn!(
+                                "mmap shm file '{}': {:?}. ignore this shm file.",
+                                p.display(),
+                                e
+                            );
+                            continue;
+                        }
+                    }
+                }
+            };
+            info!("loaded shm file: {}", p.display());
+            let mmap = Mutex::new(mmap);
+            shm_pool
+                .entry(file_size as usize)
+                .or_insert_with(|| vec![])
+                .push(mmap);
+        }
+        shm_pool
+    }
+
+    /// Acquire the shm memory for the specified size in the specified numa node
+    ///
+    /// Make sure that the thread calling this function and the thread that using
+    /// the memory returned by this function are in the same numa node and make sure
+    /// the thread that using the returned memory will not be dispatched to other numa nodes,
+    /// otherwise the performance of using returned memory will be very low
+    pub fn acquire(&self, size: usize) -> Option<MutexGuard<'_, MmapMut>> {
+        let numa_group = self
+            .numa_groups
+            .get(current_numa_node().unwrap_or_default().raw() as usize)?;
+        for l in numa_group.get(&size)? {
+            match l.try_lock() {
+                Ok(m) => return Some(m),
+                Err(_) => {}
+            }
+        }
+        None
+    }
+}
+
+#[cfg(not(test))]
+fn current_numa_node() -> Option<NumaNodeIndex> {
+    use crate::stacked::vanilla::numa;
+    numa::current_numa_node()
+}
+
+#[cfg(test)]
+fn current_numa_node() -> Option<NumaNodeIndex> {
+    unsafe { tests::CUR_NUMA_NODE.lock().unwrap().clone() }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::Mutex;
+
+    use crate::stacked::vanilla::numa::NumaNodeIndex;
+
+    use super::NumaPool;
+
+    pub(super) static mut CUR_NUMA_NODE: Mutex<Option<NumaNodeIndex>> = Mutex::new(None);
+
+    /// set current numa node for testing
+    fn set_current_numa_node(curr: Option<NumaNodeIndex>) {
+        unsafe {
+            *CUR_NUMA_NODE.lock().unwrap() = curr;
+        }
+    }
+
+    #[test]
+    fn test_numa_pool() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+        let temp_dir_path = temp_dir.as_ref();
+
+        fn size_fn(numa_node_idx: usize) -> usize {
+            (numa_node_idx + 1) * 10
+        }
+
+        let numa_shm_files: Vec<_> = (0..2)
+            .map(|numa_node_idx| {
+                (0..2).map(move |i| {
+                    let path = temp_dir_path.join(format!("numa_{}_{}", numa_node_idx, i));
+
+                    fs::write(&path, " ".repeat(size_fn(numa_node_idx)))
+                        .expect("Failed to write data");
+                    path
+                })
+            })
+            .collect();
+        let numa_pool = NumaPool::new(numa_shm_files);
+
+        let mut mems = Vec::new();
+        for numa_node_idx in 0..2 {
+            let size = size_fn(numa_node_idx);
+            let no_exist_size = size + 1;
+
+            set_current_numa_node(Some(NumaNodeIndex::new(numa_node_idx as u32)));
+
+            for _ in 0..2 {
+                // Test for normal memory acquire
+                let mem = numa_pool.acquire(size);
+                assert!(mem.is_some());
+                mems.push(mem);
+
+                // Test to acquire the shared memory of non-existent memory size
+                assert!(
+                    numa_pool.acquire(no_exist_size).is_none(),
+                    "acquire non-existent memory size should return None"
+                );
+            }
+        }
+
+        // Test when NumaPool is empty
+        for numa_node_idx in 0..2 {
+            let size = size_fn(numa_node_idx);
+            set_current_numa_node(Some(NumaNodeIndex::new(numa_node_idx as u32)));
+
+            for _ in 0..2 {
+                assert!(
+                    numa_pool.acquire(size).is_none(),
+                    "acquire memory from empty NumaPool should return None"
+                );
+            }
+        }
+
+        drop(mems);
+
+        for numa_node_idx in 0..2 {
+            let size = size_fn(numa_node_idx);
+            set_current_numa_node(Some(NumaNodeIndex::new(numa_node_idx as u32)));
+
+            for _ in 0..2 {
+                // Test for normal memory acquire
+                let mem = numa_pool.acquire(size);
+                assert!(mem.is_some());
+            }
+        }
+    }
+}

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
@@ -101,7 +101,8 @@ impl NumaPool {
 
     /// Acquire the shm memory for the specified size
     ///
-    /// Acquire returns the memory of the NUMA node where the caller thread is located.
+    /// Acquire returns the shared memory of the NUMA node where the caller thread is located 
+    /// if there is enough shared memory.
     /// Make sure that the caller thread and the thread that using the memory returned
     /// by this function are in the same NUMA node and make sure the thread that using
     /// the returned memory will not be dispatched to other NUMA nodes, otherwise the

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
@@ -99,12 +99,13 @@ impl NumaPool {
         shm_pool
     }
 
-    /// Acquire the shm memory for the specified size in the specified numa node
+    /// Acquire the shm memory for the specified size
     ///
-    /// Make sure that the thread calling this function and the thread that using
-    /// the memory returned by this function are in the same numa node and make sure
-    /// the thread that using the returned memory will not be dispatched to other numa nodes,
-    /// otherwise the performance of using returned memory will be very low
+    /// Acquire returns the memory of the NUMA node where the caller thread is located.
+    /// Make sure that the caller thread and the thread that using the memory returned 
+    /// by this function are in the same NUMA node and make sure the thread that using 
+    /// the returned memory will not be dispatched to other NUMA nodes, otherwise the 
+    /// performance of using returned memory will be very low
     pub fn acquire(&self, size: usize) -> Option<MutexGuard<'_, MmapMut>> {
         let numa_group = self
             .numa_groups

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
@@ -93,7 +93,7 @@ impl NumaPool {
             let mmap = Mutex::new(mmap);
             shm_pool
                 .entry(file_size as usize)
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(mmap);
         }
         shm_pool
@@ -128,7 +128,7 @@ fn current_numa_node() -> Option<NumaNodeIndex> {
 
 #[cfg(test)]
 fn current_numa_node() -> Option<NumaNodeIndex> {
-    tests::CUR_NUMA_NODE.lock().unwrap().clone()
+    *tests::CUR_NUMA_NODE.lock().unwrap()
 }
 
 #[cfg(test)]

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling/shm.rs
@@ -102,9 +102,9 @@ impl NumaPool {
     /// Acquire the shm memory for the specified size
     ///
     /// Acquire returns the memory of the NUMA node where the caller thread is located.
-    /// Make sure that the caller thread and the thread that using the memory returned 
-    /// by this function are in the same NUMA node and make sure the thread that using 
-    /// the returned memory will not be dispatched to other NUMA nodes, otherwise the 
+    /// Make sure that the caller thread and the thread that using the memory returned
+    /// by this function are in the same NUMA node and make sure the thread that using
+    /// the returned memory will not be dispatched to other NUMA nodes, otherwise the
     /// performance of using returned memory will be very low
     pub fn acquire(&self, size: usize) -> Option<MutexGuard<'_, MmapMut>> {
         let numa_group = self
@@ -128,7 +128,7 @@ fn current_numa_node() -> Option<NumaNodeIndex> {
 
 #[cfg(test)]
 fn current_numa_node() -> Option<NumaNodeIndex> {
-    unsafe { tests::CUR_NUMA_NODE.lock().unwrap().clone() }
+    tests::CUR_NUMA_NODE.lock().unwrap().clone()
 }
 
 #[cfg(test)]
@@ -136,17 +136,19 @@ mod tests {
     use std::fs;
     use std::sync::Mutex;
 
+    use lazy_static::lazy_static;
+
     use crate::stacked::vanilla::numa::NumaNodeIndex;
 
     use super::NumaPool;
 
-    pub(super) static mut CUR_NUMA_NODE: Mutex<Option<NumaNodeIndex>> = Mutex::new(None);
+    lazy_static! {
+        pub(super) static ref CUR_NUMA_NODE: Mutex<Option<NumaNodeIndex>> = Mutex::new(None);
+    }
 
     /// set current numa node for testing
     fn set_current_numa_node(curr: Option<NumaNodeIndex>) {
-        unsafe {
-            *CUR_NUMA_NODE.lock().unwrap() = curr;
-        }
+        *CUR_NUMA_NODE.lock().unwrap() = curr;
     }
 
     #[test]

--- a/storage-proofs-porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/mod.rs
@@ -15,6 +15,8 @@ mod graph;
 mod labeling_proof;
 #[cfg(feature = "multicore-sdr")]
 mod memory_handling;
+#[cfg(feature = "multicore-sdr")]
+mod numa;
 mod params;
 mod porep;
 mod proof;

--- a/storage-proofs-porep/src/stacked/vanilla/numa.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/numa.rs
@@ -1,0 +1,47 @@
+use libc::{self, c_int};
+
+#[link(name = "numa", kind = "dylib")]
+extern "C" {
+    /// Check if NUMA support is enabled. Returns -1 if not enabled, in which case other functions will undefined
+    fn numa_available() -> c_int;
+    ///  Returns the NUMA node corresponding to a CPU, or -1 if the CPU is invalid
+    fn numa_node_of_cpu(cpu: c_int) -> c_int;
+}
+
+lazy_static! {
+    static ref NUMA_AVAILABLE: bool = unsafe { numa_available() >= 0 };
+}
+
+/// Index of a NUMA node.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct NumaNodeIndex(u32);
+
+impl NumaNodeIndex(u32) {
+    /// Returns NUMA node index of c_int type
+    pub fn raw(&self) -> c_int {
+        self.0 as c_int
+    }
+}
+
+/// Returns the current NUMA node on which the thread is running.
+///
+/// Since threads may migrate to another node with the scheduler,
+/// you need to bind the current worker thread to the specified core when calling this function
+pub fn current_node() -> NumaNodeIndex {
+    unsafe {
+        if !*NUMA_AVAILABLE {
+            return NumaNodeIndex(0);
+        }
+        let cpu = libc::sched_getcpu();
+        // Use 0 as fallback if sched_getcpu call fails
+        if cpu < 0 {
+            return NumaNodeIndex(0);
+        }
+        let node = unsafe { numa_node_of_cpu(cpu) };
+        // If libnuma cannot find the appropriate node, then use 0 as fallback.
+        if node < 0 {
+            return NumaNodeIndex(0);
+        }
+        NumaNodeIndex(node as u32)
+    }
+}

--- a/storage-proofs-porep/src/stacked/vanilla/numa.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/numa.rs
@@ -11,6 +11,7 @@ use libc::c_int;
 pub struct NumaNodeIndex(u32);
 
 impl NumaNodeIndex {
+    #[allow(dead_code)]
     pub fn new(idx: u32) -> Self {
         Self(idx)
     }

--- a/storage-proofs-porep/src/stacked/vanilla/numa.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/numa.rs
@@ -1,47 +1,76 @@
-use libc::{self, c_int};
+#[cfg(target_os = "linux")]
+pub use linux::*;
 
-#[link(name = "numa", kind = "dylib")]
-extern "C" {
-    /// Check if NUMA support is enabled. Returns -1 if not enabled, in which case other functions will undefined
-    fn numa_available() -> c_int;
-    ///  Returns the NUMA node corresponding to a CPU, or -1 if the CPU is invalid
-    fn numa_node_of_cpu(cpu: c_int) -> c_int;
-}
+#[cfg(not(target_os = "linux"))]
+pub use unsupported::*;
 
-lazy_static! {
-    static ref NUMA_AVAILABLE: bool = unsafe { numa_available() >= 0 };
-}
+use libc::c_int;
 
 /// Index of a NUMA node.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct NumaNodeIndex(u32);
 
-impl NumaNodeIndex(u32) {
+impl NumaNodeIndex {
+    pub fn new(idx: u32) -> Self {
+        Self(idx)
+    }
+
     /// Returns NUMA node index of c_int type
     pub fn raw(&self) -> c_int {
         self.0 as c_int
     }
 }
 
-/// Returns the current NUMA node on which the thread is running.
-///
-/// Since threads may migrate to another node with the scheduler,
-/// you need to bind the current worker thread to the specified core when calling this function
-pub fn current_node() -> NumaNodeIndex {
-    unsafe {
+#[cfg(target_os = "linux")]
+pub mod linux {
+
+    use lazy_static::lazy_static;
+    use libc::{self, c_int};
+
+    use super::NumaNodeIndex;
+
+    #[link(name = "numa", kind = "dylib")]
+    extern "C" {
+        /// Check if NUMA support is enabled. Returns -1 if not enabled, in which case other functions will undefined
+        fn numa_available() -> c_int;
+        ///  Returns the NUMA node corresponding to a CPU core, or -1 if the CPU core is invalid
+        fn numa_node_of_cpu(cpu: c_int) -> c_int;
+    }
+
+    lazy_static! {
+        static ref NUMA_AVAILABLE: bool = unsafe { numa_available() >= 0 };
+    }
+
+    /// Returns the current NUMA node on which the thread is running.
+    ///
+    /// Since threads may migrate to another node with the scheduler,
+    /// you need to bind the current worker thread to the specified core when calling this function
+    #[allow(dead_code)]
+    pub fn current_numa_node() -> Option<NumaNodeIndex> {
         if !*NUMA_AVAILABLE {
-            return NumaNodeIndex(0);
+            return None;
         }
-        let cpu = libc::sched_getcpu();
-        // Use 0 as fallback if sched_getcpu call fails
+        let cpu = unsafe { libc::sched_getcpu() };
+        // Return None if sched_getcpu call fails
         if cpu < 0 {
-            return NumaNodeIndex(0);
+            return None;
         }
         let node = unsafe { numa_node_of_cpu(cpu) };
-        // If libnuma cannot find the appropriate node, then use 0 as fallback.
+        // If libnuma cannot find the appropriate node, then return None
         if node < 0 {
-            return NumaNodeIndex(0);
+            return None;
         }
-        NumaNodeIndex(node as u32)
+        Some(NumaNodeIndex(node as u32))
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod unsupported {
+
+    use super::NumaNodeIndex;
+
+    #[allow(dead_code)]
+    pub fn current_numa_node() -> Option<NumaNodeIndex> {
+        None
     }
 }

--- a/storage-proofs-porep/src/stacked/vanilla/numa.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/numa.rs
@@ -23,7 +23,7 @@ impl NumaNodeIndex {
 }
 
 #[cfg(target_os = "linux")]
-pub mod linux {
+mod linux {
 
     use lazy_static::lazy_static;
     use libc::{self, c_int};


### PR DESCRIPTION
resolve ipfs-force-community/venus-cluster#85

1. Add `shm::NumaPool`, used to allocate pre-set shared memory.
2. Modify the pc1 phase `setup_create_label_memory` function. Prefer to get the available memory from the current numa noode, or use anonymous mmap to allocate memory if it is not available.