### PR TITLE
refactor: pc1 layer memory

### DIFF
--- a/rust-fil-proofs.config.toml.sample
+++ b/rust-fil-proofs.config.toml.sample
@@ -33,26 +33,3 @@ rows_to_discard = 2
 
 # This enables multicore SDR replication
 use_multicore_sdr = false
-
-# The shared memory directory pattern.
-# default value: "filecoin-proof-label/numa_$NUMA_NODE_INDEX"
-# $NUMA_NODE_INDEX corresponds to the index of the numa node, 
-# and you should make sure that the shared memory files stored in this folder were created on that numa node ($NUMA_NODE_INDEX)
-# If using the default value will match the following shared memory files:
-# NUMA node 0:
-# /dev/shm/filecoin-proof-label/numa_0/mem_32GiB_1
-# /dev/shm/filecoin-proof-label/numa_0/mem_64GiB_1
-# /dev/shm/filecoin-proof-label/numa_0/any_file_name
-# NUMA node 1:
-# /dev/shm/filecoin-proof-label/numa_1/mem_32GiB_1
-# /dev/shm/filecoin-proof-label/numa_1/mem_32GiB_1
-# /dev/shm/filecoin-proof-label/numa_1/any_file_name
-# NUMA node N:
-# ...
-#
-# When creating a label in the pc1 phase, two large blocks of memory of the same sector size are requested. 
-# The system will acquire memory from the configured SHM directory, which is the same size with the sector 
-# and on the same NUMA node with the PC1 worker thread. that is used to avoid requesting memory across NUMA nodes.
-# If there is not enough shared memory that satisfies the condition, the memory is requested in the same way as before
-#
-# multicore_sdr_shm_numa_dir_pattern = "filecoin-proof-label/numa_$NUMA_NODE_INDEX"

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -43,8 +43,6 @@ yastl = "0.1.2"
 fil_logger = "0.1"
 pairing = "0.21"
 blstrs = "0.4.0"
-glob = "0.3.0"
-regex = "1"
 
 [target."cfg(target_arch = \"aarch64\")".dependencies]
 sha2 = { version = "0.9.3", features = ["compress", "asm"] }
@@ -55,6 +53,7 @@ sha2 = { version = "0.9.3", features = ["compress"] }
 tempfile = "3"
 rand_xorshift = "0.3.0"
 criterion = "0.3.2"
+glob = "0.3.0"
 pretty_env_logger = "0.4.0"
 filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
 

--- a/storage-proofs-porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/mod.rs
@@ -30,5 +30,6 @@ pub use column_proof::ColumnProof;
 pub use encoding_proof::EncodingProof;
 pub use graph::{StackedBucketGraph, StackedGraph, EXP_DEGREE};
 pub use labeling_proof::LabelingProof;
+pub use memory_handling::init_numa_mem_pool;
 pub use params::*;
 pub use proof::{StackedDrg, TreeRElementData, TOTAL_PARENTS};


### PR DESCRIPTION
resolve https://github.com/ipfs-force-community/venus-cluster/issues/350

* renmae mod `shm` to `numa_mem_pool`
* removed the `scan_shm_files` function and the `storage_proofs_core::settings::SETTINGS::multicore_sdr_shm_numa_dir_pattern` configuration item
  Now the caller needs to call the `storage_proofs_porep::stacked::init_numa_mem_pool` function to initialize the NumaMemPool